### PR TITLE
adds vault setup script

### DIFF
--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -1,1 +1,5 @@
 FROM golang:1.6
+
+RUN curl https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh | bash
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang:1.6
 
-RUN curl https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh | bash
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
+RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
first draft of the stuff needed to pull ENV variables from vault and get them into docker images at ENV variables. 

TODO: 
- [x] setup the entrypoint.sh to look for a flag and only run consul-template if we have it turned on. coming soon!
- [x] update the `README.md` with what terraform atlas variables are required to get this working. 
- [x] switch to `APP_ENV` and `APP_NAME` for the secret path
