### PR TITLE
Creating a base Golang docker image

### DIFF
--- a/1.11/Dockerfile
+++ b/1.11/Dockerfile
@@ -6,6 +6,7 @@ ENV SERVICE_USER service
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
 
+RUN mkdir -p $SERVICE_ROOT
 RUN groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER
 WORKDIR $SERVICE_ROOT
 

--- a/1.11/Dockerfile
+++ b/1.11/Dockerfile
@@ -1,8 +1,12 @@
 FROM golang:1.11
 
-# No service root due to the necessity of it being in the GOPATH
+ENV SERVICE_ROOT /go/src/github.com/articulate/service
 ENV SERVICE_USER service
+
 ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
 RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
+
+RUN groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER
+WORKDIR $SERVICE_ROOT
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/1.11/Dockerfile
+++ b/1.11/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.11
+
+# No service root due to the necessity of it being in the GOPATH
+ENV SERVICE_USER service
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
+RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,5 @@ build_1_5:
 build_1_6:
 	docker build -t articulate/articulate-golang:1.6 1.6/
 
+build_1_11:
+	docker build -t articulate/articulate-golang:1.11 1.11/


### PR DESCRIPTION
Now that we have a few Golang related things we need a docker file for, might as well centralize the base layers. Go 1.12 is still not GA, will be soon.

Decided to create a generic service root in the GOPATH. Not sure if it will be used.