### PR TITLE
Adding Go 1.13

### DIFF
--- a/1.13/Dockerfile
+++ b/1.13/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.13
+
+# With go modules enabled there is no need to create a service dir in the normal GOPATH
+ENV GO111MODULE on
+ENV SERVICE_ROOT /service
+ENV SERVICE_USER service
+
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/install.sh /tmp/consul_template_install.sh
+RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
+
+RUN mkdir -p $SERVICE_ROOT
+RUN groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER
+WORKDIR $SERVICE_ROOT
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,6 @@ build_1_11:
 
 build_1_12:
 	docker build -t articulate/articulate-golang:1.12 1.12/
+
+build_1_13:
+	docker build -t articulate/articulate-golang:1.13 1.13/


### PR DESCRIPTION
Adding Golang 1.13. Keeping `GO111MODULE on` explicitly. AFAIK it is on by default now but I wanted it to be explicit until it was a first class feature.