### PR TITLE
ci(build): allow to skip cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,21 @@
 name: Build
 
 on:
+  pull_request:
   push:
     branches:
       - main
   schedule:
-    # Run everyday
-    - cron: "0 0 * * *"
+    # every weekday
+    - cron: '0 0 * * 1-5'
+    # every sunday (no-cache)
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+    inputs:
+      no-cache:
+        description: 'Skip Docker cache'
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -29,8 +38,10 @@ jobs:
       - uses: docker/build-push-action@v3
         with:
           context: ${{ matrix.golang }}
-          push: true
+          pull: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' }}
           tags: articulate/articulate-golang:${{ matrix.golang }}
           platforms: linux/amd64,linux/arm64/v8
           cache-from: type=registry,ref=articulate/articulate-golang:${{ matrix.golang }}
           cache-to: type=inline
+          no-cache: ${{ github.event.schedule == '0 0 * * 0' || (github.event_name == 'workflow_dispatch' && inputs.no-cache) }}


### PR DESCRIPTION
Run on pull_requests to make sure nothing was introduced in the PR that would break the build

Skip cache every week and allow it to be skipped manually